### PR TITLE
Prepare for release of 0.5.0 to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.6.0 (2025-05-28)
+
+### Feat
+
+- Add fetch command for downloading media from URLs
+- Add show_configs command to display gallery-dl and yt-dlp configurations
+- Update mkdocs configuration and enhance bot command error handling
+- Update settings.local.json to enhance web fetch capabilities
+- Enhance bot functionality and improve async handling
+- Complete all epics of strategy pattern implementation with production integration
+- Implement strategy pattern for download operations across platforms
+
+### Fix
+
+- Update bot setup hook method for consistency
+
 ## v0.5.0 (2025-05-28)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@
     name = "boss-bot"
     readme = "README.md"
     requires-python = ">=3.12"
-    version = "0.5.0"
+    version = "0.6.0"
 
     [project.scripts]
         # clctl       = "boss_bot.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "boss-bot"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Release preparation triggered by @Malcolm Jones. Once merged, create a GitHub release for '0.6.0' to publish.