### PR TITLE
Prepare for release of 0.10.0 to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.11.0 (2025-06-21)
+
+### Feat
+
+- Enhance download strategies with directory management
+- Expand upload system documentation and configuration
+- Add upload functionality to downloads cog
+
 ## v0.10.0 (2025-06-21)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@
     name = "boss-bot"
     readme = "README.md"
     requires-python = ">=3.12"
-    version = "0.10.0"
+    version = "0.11.0"
 
     [project.scripts]
         # clctl       = "boss_bot.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "boss-bot"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Release preparation triggered by @Malcolm Jones. Once merged, create a GitHub release for '0.11.0' to publish.