### PR TITLE
Prepare for release of 0.11.0 to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v0.12.0 (2025-06-23)
+
+### Feat
+
+- Add support for YouTube Shorts in download handler and tests
+- Introduce MCP Client Library Implementation Plan and LangGraph Lookup Command
+- Add comprehensive dpytest tests for YouTube download command
+- Enhance YouTube download commands and documentation
+- Enhance YouTube download workflow and directory management
+
+### Fix
+
+- Update UploadManager to include type hint for compression result and improve pylint configuration
+
+### Refactor
+
+- Update YouTube download tests for clarity and structure validation
+
 ## v0.11.0 (2025-06-21)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@
     name = "boss-bot"
     readme = "README.md"
     requires-python = ">=3.12"
-    version = "0.11.0"
+    version = "0.12.0"
 
     [project.scripts]
         # clctl       = "boss_bot.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "boss-bot"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Release preparation triggered by @Malcolm Jones. Once merged, create a GitHub release for '0.12.0' to publish.